### PR TITLE
Pass the whole embed value through.

### DIFF
--- a/src/EngageApi.php
+++ b/src/EngageApi.php
@@ -25,7 +25,7 @@ class EngageApi {
           $decoded = json_decode($api_result['Response']);
 
           if ($decoded->Error == null) {
-            $embed = json_encode($decoded->Article->Embed);
+            $embed = json_encode($decoded->Article->Embed, JSON_UNESCAPED_UNICODE);
             $embed = $this->stripSpecialCharsSlashesQuotes($embed);
           }
           else {


### PR DESCRIPTION
The "Body" content escapes characters into the UTF-8 values.

The "Embed" content does not. It includes the raw unicode characters (mdash, copyright, etc.). So those characters were getting escaped during JSON encoding.